### PR TITLE
Fix link to manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RandomizedLinAlg.jl is a [Julia](https://julialang.org/) package that provides r
 
 This package was split off from [IterativeSolvers.jl](https://github.com/JuliaMath/IterativeSolvers.jl) as randomized algorithms were not considered well-established and potentially unstable.
 
-See the [**manual**](https://haampie.github.io/RandomizedLinAlg.jl/latest/) for the available methods.
+See the [**manual**][docs-latest-url] for the available methods.
 
 [1]: Halko, Nathan, Per-Gunnar Martinsson, and Joel A. Tropp. "Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions." SIAM review 53.2 (2011): 217-288.
 


### PR DESCRIPTION
The old url pointed to the repo before it was moved to the JuliaLinearAlgebra org.